### PR TITLE
Provide Docker Images for armv7 and arm64 (Raspberry Pis)

### DIFF
--- a/.github/workflows/docker-publish-dev.yml
+++ b/.github/workflows/docker-publish-dev.yml
@@ -28,8 +28,9 @@ jobs:
           tags : type=raw,latest-dev
       
       - name: Build and push Docker image
-        uses: docker/build-push-action@v2
+        uses: docker/build-push-action@v3
         with:
           push: true
+          platforms: linux/amd64,linux/arm64,linux/arm/v7
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}

--- a/.github/workflows/docker-publish-release.yml
+++ b/.github/workflows/docker-publish-release.yml
@@ -28,8 +28,9 @@ jobs:
           images: ${{ github.repository }}
       
       - name: Build and push Docker image
-        uses: docker/build-push-action@v2
+        uses: docker/build-push-action@v3
         with:
           push: true
+          platforms: linux/amd64,linux/arm64,linux/arm/v7
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}


### PR DESCRIPTION
Hey,

i wanted to run your image on a raspberry pi and found no arm release. I added arm support for 32 & 64bit and can confirm that both new images are building and running fine.

Hope to see this merged and thanks for providing the mqtt exporter 